### PR TITLE
Set emoji version to 1.7.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ covid
 colour
 distro
 duckduckgo_search
-emoji
+emoji==1.7.0
 gitpython
 glitch_this
 google-api-python-client


### PR DESCRIPTION
This fixes the error ImportError: cannot import name 'get_emoji_regexp' from 'emoji' It's probably named different in version 2.0.0 and up